### PR TITLE
fixed: useAccess is declaring as a react functional hook issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,22 @@ const Product = ({ product }) => {
 Conditional render with useAccessContext from Context API
 
 ```jsx
-const { useAccess } = useAccessContext();
+const { checkAccess } = useAccessContext();
 
-console.log(useAccess("PRODUCT_EDIT"));
+console.log(checkAccess("PRODUCT_EDIT"));
 
-return <>{useAccess("PRODUCT_EDIT") && <button>"Edit Product"</button>}</>;
+return <>{checkAccess("PRODUCT_EDIT") && <button>"Edit Product"</button>}</>;
 ```
 
 ## API
 
-- [useAccess](#useAccess)
+- [checkAccess](#checkAccess)
 - [useAccessContext](#useAccessContext)
 - [AccessMargin](#AccessMargin)
 - [AccessProvider](#AccessProvider)
 - [DefaultFallback](#DefaultFallback)
 
-## useAccess
+## checkAccess
 
 Function to check if passed string or list of strings have permission.
 
@@ -107,7 +107,7 @@ Permission or Permission List to check for restriction
 
 Current Permission List
 
-`useAccess` - The [useAccess](#useaccess) Function
+`checkAccess` - The [checkAccess](#checkaccess) Function
 
 `addPermissions` - `function` to add new permissions with existing permissions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export type {
 	IPermission,
 } from "./libs/types";
 export { AccessProvider, useAccessContext } from "./libs/useAccessContext";
-export { useAccess } from './libs/useAccess';
+export { checkAccess } from './libs/checkAccess';
 export { DefaultFallback } from './libs/DefaultFallback';
 export {default as AccessMargin} from './libs/AccessMargin';

--- a/src/libs/AccessMargin.tsx
+++ b/src/libs/AccessMargin.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { DefaultFallback } from "./DefaultFallback";
 import { IAccessMargin } from "./types";
-import { useAccess } from "./useAccess";
+import { checkAccess } from "./checkAccess";
 
 const AccessMargin: React.FC<React.PropsWithChildren<IAccessMargin>> = ({
-	to,
-	children,
-	defaultFallback,
-	fallback,
+  to,
+  children,
+  defaultFallback,
+  fallback,
 }) => {
-	if (useAccess(to)) return <>{children}</>;
-	if (fallback) return <>{fallback}</>;
-	if (defaultFallback) return <DefaultFallback />;
-	return null;
+  if (checkAccess(to)) return <>{children}</>;
+  if (fallback) return <>{fallback}</>;
+  if (defaultFallback) return <DefaultFallback />;
+  return null;
 };
 
 export default AccessMargin;

--- a/src/libs/checkAccess.tsx
+++ b/src/libs/checkAccess.tsx
@@ -1,0 +1,7 @@
+import { IPermission } from "./types";
+import { useAccessContext } from "./useAccessContext";
+
+export const checkAccess = (permission: IPermission | IPermission[]) => {
+  const { checkAccess: check } = useAccessContext();
+  return check(permission);
+};

--- a/src/libs/types.ts
+++ b/src/libs/types.ts
@@ -4,7 +4,7 @@ export type IPermission = string;
 
 export type IAccessContext = {
 	permissions: IPermission[];
-	useAccess: (permission: IPermission| IPermission[]) => boolean;
+	checkAccess: (permission: IPermission| IPermission[]) => boolean;
 	addPermissions: (permission: IPermission | IPermission[]) => void;
 	resetPermissions: (permission?: IPermission[]) => void;
 	removePermissions: (permission: IPermission | IPermission[]) => void;

--- a/src/libs/useAccess.tsx
+++ b/src/libs/useAccess.tsx
@@ -1,7 +1,0 @@
-import { IPermission } from "./types";
-import { useAccessContext } from "./useAccessContext";
-
-export const useAccess = (permission: IPermission | IPermission[]) => {
-	const { useAccess: checkAccess } = useAccessContext();
-	return checkAccess(permission);
-};

--- a/src/libs/useAccessContext.tsx
+++ b/src/libs/useAccessContext.tsx
@@ -6,7 +6,7 @@ import { IAccessContext, IAccessProvider, IPermission } from "./types";
  */
 const AccessContext = React.createContext<IAccessContext>({
   permissions: [],
-  useAccess: () => false,
+  checkAccess: () => false,
   addPermissions: () => {},
   resetPermissions: () => {},
   removePermissions: () => {},
@@ -26,7 +26,7 @@ export const AccessProvider: React.FC<React.PropsWithChildren<
     permissions || []
   );
 
-  const useAccess = (permission: IPermission | IPermission[]) =>
+  const checkAccess = (permission: IPermission | IPermission[]) =>
     typeof permission === "string"
       ? permissionList.includes(permission)
       : permission.some(p => permissionList.includes(p));
@@ -38,7 +38,7 @@ export const AccessProvider: React.FC<React.PropsWithChildren<
         /**
          * Check permissions
          */
-        useAccess,
+        checkAccess,
         /**
          * Add permission or a list of permission to the permissions list
          */


### PR DESCRIPTION
Sol: useAccess is renamed as checkAccess in the app. now the module is callable as an ordinary function instead of hook function in reactjs